### PR TITLE
Redirect mpv output to a file when there is an error :bug: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,23 +44,13 @@ For the project to function correctly, you'll need the following dependencies:
     cd kiepscy-cli
     ```
 
-2.  **Prepare video data:**
-    Ensure you have a `seasons.json` file (containing the season and episode data structure) located in the `utils/` directory within your project's root. Example path: `kiepscy-cli/utils/seasons.json`.
-
-3.  **Initialize Go module and fetch dependencies:**
-    ```bash
-    go mod init kiepscy-cli # Or `go mod init github.com/Kiki-Bouba-Game-Studio/kiepscy-cli`
-    go mod tidy
-    ```
-    The `go mod tidy` command will automatically download all required dependencies defined in your `main.go` file.
-
-4.  **Build the application:**
+2.  **Build the application:**
     ```bash
     go build
     ```
     This will compile the project and create an executable file named `kiepscy-cli` (or `kiepscy-cli.exe` on Windows) in the current directory.
 
-5.  **Run the application:**
+3.  **Run the application:**
     ```bash
     ./kiepscy-cli # On Linux/macOS
     .\kiepscy-cli.exe # On Windows

--- a/main.go
+++ b/main.go
@@ -63,15 +63,27 @@ func getSeasonsFromJSON() []Season {
 }
 
 func playVideo(url string) {
+
 	cmd := exec.Command("mpv", url)
 	stdout, err := cmd.Output()
 
 	if err != nil {
 		fmt.Println(err.Error())
+
+		logfile, err := os.CreateTemp("", "kiepscy-cli-mpv-*.log")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		logfile.Write(stdout)
+
+		if err := logfile.Close(); err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println("Logs can be found in ", logfile.Name())
 		return
 	}
-
-	fmt.Println(string(stdout))
 }
 
 var docStyle = lipgloss.NewStyle().Margin(1, 2)


### PR DESCRIPTION
Redirect mpv output to a file when there is an error, ignore stdout otherwise.

Delete unnecessary installation steps from readme.